### PR TITLE
Fix the unit test task not found if configured eagerly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 20 02:07:52 JST 2023
+#Sun Jul 30 20:53:26 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/kotlin/com/mxalbert/gradle/jacoco/android/JacocoAndroidPluginTest.kt
+++ b/src/test/kotlin/com/mxalbert/gradle/jacoco/android/JacocoAndroidPluginTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 
@@ -53,6 +54,17 @@ class JacocoAndroidPluginTest {
         assertNotNull(project.tasks.findByName("jacocoTestPaidReleaseUnitTestReport"))
         assertNotNull(project.tasks.findByName("jacocoTestFreeReleaseUnitTestReport"))
         assertNotNull(project.tasks.findByName("jacocoTestReport"))
+    }
+
+    @Test
+    fun `should work even if the tasks are eagerly configured`() {
+        project.tasks.withType(JacocoReport::class.java) {
+            // Do nothing. We just want to force the tasks to be configured.
+        }
+        project.configureAndroidLibraryAndApplyPlugin()
+        assertDoesNotThrow {
+            project.evaluate()
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #3.

We have to eagerly configure the unit test tasks but I don't think we have any other choice.