### PR TITLE
Set explicit dependencies on compile tasks

### DIFF
--- a/src/main/kotlin/com/mxalbert/gradle/jacoco/android/JacocoAndroidPlugin.kt
+++ b/src/main/kotlin/com/mxalbert/gradle/jacoco/android/JacocoAndroidPlugin.kt
@@ -91,6 +91,7 @@ class JacocoAndroidPlugin : Plugin<Project> {
                     val javaClassesDir = javaCompile.destinationDirectory
                     val javaTree = fileTree(javaClassesDir) { it.exclude(ext.excludes.get()) }
                     reportTask.classDirectories.from(javaTree)
+                    reportTask.dependsOn(javaCompile)
 
                     if (plugins.hasPlugin("kotlin-android")) {
                         val kotlinCompile =
@@ -99,6 +100,7 @@ class JacocoAndroidPlugin : Plugin<Project> {
                         val kotlinTree =
                             fileTree(kotlinClassesDir) { it.exclude(ext.excludes.get()) }
                         reportTask.classDirectories.from(kotlinTree)
+                        reportTask.dependsOn(kotlinCompile)
                     }
 
                     reportTask.reports { reports ->


### PR DESCRIPTION
The unit test report task sometimes fails with the following error:

    Reason: Task ':app:jacocoTestDebugUnitTestReport' uses this output of task
    ':app:compileDebugKotlin' without declaring an explicit or implicit dependency.
    This can lead to incorrect results being produced, depending on what order the
    tasks are executed.